### PR TITLE
fixing mkdir for objects

### DIFF
--- a/makefile
+++ b/makefile
@@ -17,7 +17,7 @@ $(TARGET): $(OBJECTS)
 	@echo " $(CC) $^ -o $(TARGET) $(LIB)"; $(CC) $^ -o $(TARGET) $(LIB)
 
 $(BUILDDIR)/%.o: $(SRCDIR)/%.$(SRCEXT)
-	@mkdir -p $(BUILDDIR)
+	@mkdir -p $(dir $@)
 	@echo " $(CC) $(CFLAGS) $(INC) -c -o $@ $<"; $(CC) $(CFLAGS) $(INC) -c -o $@ $<
 
 clean:


### PR DESCRIPTION
The `build/classes` won't be created with using `$(BUILDDIR)`.

```
 g++  -std=c++11  -c -o build/main.o src/main.cpp
 g++  -std=c++11  -c -o build/classes/LifeFrom.o src/classes/LifeFrom.cpp
Assembler messages:
Fatal error: can't create build/classes/LifeFrom.o: No such file or directory
makefile:20: recipe for target 'build/classes/LifeFrom.o' failed
make: *** [build/classes/LifeFrom.o] Error 1
```